### PR TITLE
feat(config): allow disabling of cortex via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,35 @@ MIX_ENV=test iex -S mix
 ```
 
 
+## Enabling and Disabling
+
+Whether cortex runs at all can be configured via the configuration of your
+application. By default cortex does run.
+
+```ex
+config :cortex,
+  enabled: false
+```
+
+Cortex also supports the Elixir / Erlang convention of a
+`{:system, ENV_VAR_NAME, default_value}` in the config file.
+
+
+For example, if you wanted to have cortex disabled in your project by default,
+you could add the following to your `config.exs`:
+
+```ex
+config :cortex,
+  enabled: {:system, "CORTEX_ENABLED", false}
+```
+
+Then, to run cortex you would start `iex` with the following options:
+
+```
+CORTEX_ENABLED=true iex -S mix
+```
+
+
 ## Umbrella Applications
 
 If you're running an umbrella application, add Cortex to the dependencies of

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,5 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+config :cortex,
+    enabled: {:system, "CORTEX_ENABLED", true}

--- a/lib/cortex/application.ex
+++ b/lib/cortex/application.ex
@@ -8,30 +8,64 @@ defmodule Cortex.Application do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     cond do
       Mix.env in [:dev, :test] ->
-        children = [
-          FileWatcher.child_spec,
-          worker(Reloader, []),
-          worker(Controller, [])
-        ]
-
-        env_specific_children =
-          case Mix.env do
-            :dev ->
-              []
-            :test ->
-              [worker(TestRunner, [])]
+        children =
+          if enabled?() do
+            children()
+          else
+            []
           end
 
-        opts = [strategy: :one_for_one, name: Cortex.Supervisor]
-
-        Supervisor.start_link(children ++ env_specific_children, opts)
+        Supervisor.start_link(children, strategy: :one_for_one, name: Cortex.Supervisor)
 
       true ->
         {:error, "Only :dev and :test environments are allowed"}
+    end
+  end
+
+  defp children() do
+    import Supervisor.Spec, warn: false
+
+    children = [
+      FileWatcher.child_spec,
+      worker(Reloader, []),
+      worker(Controller, [])
+    ]
+
+    env_specific_children =
+      case Mix.env do
+        :dev ->
+          []
+        :test ->
+          [worker(TestRunner, [])]
+      end
+
+    children ++ env_specific_children
+  end
+
+
+  defp enabled? do
+    case Application.get_env(:cortex, :enabled, true) do
+      bool when is_boolean(bool) ->
+        bool
+      {:system, env_var, default} ->
+        get_system_var(env_var, default)
+      invalid ->
+        raise "Invalid config value for Cortex `:enabled`: #{inspect invalid}"
+    end
+  end
+
+  defp get_system_var(env_var, default) do
+    case System.get_env(env_var) do
+      nil ->
+        default
+      truthy when truthy in ["YES", "yes", "true", "TRUE", "1"] ->
+        true
+      falsey when falsey in ["NO", "no", "false", "FALSE", "0"] ->
+        false
+      _ ->
+        raise "Unparsable Cortex Environment Variable '#{env_var}'"
     end
   end
 end


### PR DESCRIPTION
Per feedback in #4, this PR adds the ability to configure whether Cortex is enabled.

Ultimately we may want to allow per-environment configuration of pipeline stages, but for now this works.

Note that this still keeps cortex enabled by default but presents a mechanism to disable it by default per-app.