### PR TITLE
Add a command for running all pipeline stages on all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,13 @@ iex -S mix
 
 This is enough to get live-reload on file change when editing your app.
 
+### Commands
 
-#### Phoenix
+Some commands intended to be used via the shell are provided in the `Cortex`
+module:
 
-If you are running a phoenix application,
-make sure you are running the app in interactive mode:
-
-```sh
-iex -S mix phoenix.server
-```
+- `Cortex.all` - run all stages (currently reload and test runner) on all files
+  in the project
 
 
 ### Test Runner
@@ -95,6 +93,16 @@ Then, to run cortex you would start `iex` with the following options:
 
 ```
 CORTEX_ENABLED=true iex -S mix
+```
+
+
+## Phoenix
+
+If you are running a phoenix application,
+make sure you are running the app in interactive mode:
+
+```sh
+iex -S mix phoenix.server
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ CORTEX_ENABLED=true iex -S mix
 
  - [x] Reload Modules
  - [x] Rerun tests
+ - [x] Reload all modules and run all tests from the IEx shell
+ - [ ] Reload and run tests for a specific module from the IEx shell
  - [ ] [Credo](https://github.com/rrrene/credo) runner
  - [ ] [Dialyzer](https://github.com/jeremyjh/dialyxir/) runner
  - [ ] [ExDash](https://github.com/urbint/ex_dash) runner

--- a/lib/cortex.ex
+++ b/lib/cortex.ex
@@ -39,4 +39,10 @@ defmodule Cortex do
   will re-run that file's tests.
 
   """
+
+  @doc """
+  Run all stages in the current Cortex pipeline on all files (ie, recompile all
+  files, run all tests, etc.). Returns immediately, then runs asynchronously
+  """
+  defdelegate all, to: Cortex.Controller, as: :run_all
 end

--- a/lib/cortex/reloader.ex
+++ b/lib/cortex/reloader.ex
@@ -27,6 +27,8 @@ defmodule Cortex.Reloader do
   # Controller Stage Callbacks
   ##########################################
 
+  def run_all, do: recompile()
+
   def file_changed(:lib, path), do: reload_or_recompile(path)
 
   def file_changed(:test, path) do
@@ -40,7 +42,6 @@ defmodule Cortex.Reloader do
   def file_changed(:unknown, _), do: :ok
 
   def cancel_on_error?, do: true
-
 
   ##########################################
   # GenServer Callbacks

--- a/lib/cortex/test_runner.ex
+++ b/lib/cortex/test_runner.ex
@@ -57,6 +57,11 @@ defmodule Cortex.TestRunner do
   # Controller Stage Callbacks
   ##########################################
 
+  @spec run_all :: :ok | {:error, String.t}
+  def run_all do
+    GenServer.call(__MODULE__, :run_all)
+  end
+
   def file_changed(relevant, path) when relevant in [:lib, :test] do
     run_tests_for_file(path)
   end
@@ -76,35 +81,64 @@ defmodule Cortex.TestRunner do
 
   def handle_call({:run_tests_for_file, path, _opts}, _from, state) do
     case test_file_for_path(path) do
-      :not_found ->
-        {:reply, :ok, state}
-
+      :not_found -> {:reply, :ok, state}
       test_path ->
-        files_to_load =
-          [test_helper(path), test_path]
-
-        compiler_errors =
-          files_to_load
-          |> Stream.map(&Reloader.reload_file/1)
-          |> Enum.reject(&(&1 == :ok))
-
-        with [] <- compiler_errors do
-          task =
-            Task.async(ExUnit, :run, [])
-
-          ExUnit.Server.cases_loaded()
-          Task.await(task, :infinity)
-
-          {:reply, :ok, state}
-        else
-          errors ->
-            compiler_error_descs =
-              errors
-              |> Stream.map(&elem(&1, 1))
-              |> Enum.join("\n")
-
-            {:reply, {:error, compiler_error_descs}, state}
+        case run_test_files([test_path]) do
+          :ok -> {:reply, :ok, state}
+          err = {:error, _} -> err
         end
+    end
+  end
+
+  def handle_call(:run_all, _from, state) do
+    case run_test_files() do
+      :ok -> {:reply, :ok, state}
+      err = {:error, _} -> err
+    end
+  end
+
+  def run_test_files, do: run_test_files(all_test_files())
+  def run_test_files([]), do: :ok
+  def run_test_files(files) do
+    files
+    |> Enum.group_by(&test_helper/1)
+    |> Enum.map(fn {helper, files} -> run_test_files(helper, files) end)
+    |> Enum.find(:ok, fn
+      :ok         -> false
+      {:error, _} -> true
+    end)
+  end
+
+  def run_test_files(_test_helper, []), do: :ok
+  def run_test_files(test_helper, files) do
+    files_to_load = [test_helper | files]
+    compiler_errors =
+      files_to_load
+      |> Stream.map(&Reloader.reload_file/1)
+      |> Enum.reject(&(&1 == :ok))
+
+    with [] <- compiler_errors do
+      task = Task.async(ExUnit, :run, [])
+      ExUnit.Server.cases_loaded()
+      Task.await(task, :infinity)
+      :ok
+    else errors ->
+      compiler_error_descs =
+        errors
+        |> Stream.map(&elem(&1, 1))
+        |> Enum.join("\n")
+
+      {:error, compiler_error_descs}
+    end
+  end
+
+  defp all_test_files do
+    config = Mix.Project.config
+    test_paths =
+      config[:test_paths] ||
+        if File.dir?("test"), do: ["test"], else: []
+    Enum.flat_map test_paths, fn p ->
+      p |> Path.join("**/*_test.exs") |> Path.wildcard
     end
   end
 


### PR DESCRIPTION
Coming from Guard in ruby-land, one thing I often do is after working for a while adding some functionality to a module, I'll quickly run all the tests for the entire project - having tests run only for that file is nice while working as a quick feedback loop, but there's always the possibility that the change I've just introduced has broken some other, distant dependent part of the code, and I always like to run everything just as a quick last check before I open a PR. I'd been missing that functionality when working with Cortex, so I've gone ahead and implemented it here. I've done this by adding a separate callback to the `Cortex.Controller.Stage` behaviour, along with some additional branching in the `Cortex.Controller.run_pipeline` function to handle different kinds of things that might happen as part of a pipeline run (run_all vs run_file, maybe a couple more later?).

As you all know I'm still teaching myself Elixir/Erlang/OTP (in fact attempting to add this feature was part of that self-education endeavor), so it's possible (likely, even) that I've missed some idioms or obvious ways of doing things here and there - please let me know if that's the case and I'm obviously more than happy to address any feedback you might have.

It's also possible this isn't something you ever want as part of Cortex (it's doable from another terminal window via `mix test`, after all), which is also fine! Especially given that I didn't talk to anybody before I went off and wrote this, I wouldn't be offended if you decided to close it outright. I learned a lot and had a lot of fun writing it!