### PR TITLE
feat(file_watcher): Debounce file changes

### DIFF
--- a/lib/cortex/test_runner.ex
+++ b/lib/cortex/test_runner.ex
@@ -135,7 +135,7 @@ defmodule Cortex.TestRunner do
     do: ExUnit.configure(exclude: [:test], include: focus)
 
 
-  defp clear_focus(),
+  defp clear_focus,
     do: ExUnit.configure(exclude: [], include: [])
 
 


### PR DESCRIPTION
The original impetus for this is an apparent bug with inotifywait on
linux where every time I save a file four file change events are fired.
Even if that bug is fixed, though, it's still nice to debounce file
change events so that operations which change files a lot (git rebase,
for example) only end up running one test run.

I played with the debounce timer a lot and at least on my machine 100ms
provides a pretty nice balance of responsiveness to file save without
ever really seeing double-test-runs.