### PR TITLE
fix(reloader): handle undefined function error

### DIFF
--- a/lib/cortex/reloader.ex
+++ b/lib/cortex/reloader.ex
@@ -112,6 +112,9 @@ defmodule Cortex.Reloader do
 
               %{message: message} ->
                 "#{error_module}:\n\n\t#{message}\n"
+
+              %{arity: arity, function: func, module: mod} ->
+                "#{error_module}:\n\n\t#{mod}.#{func}/#{arity}\n"
             end
 
           {{:error, error_message}, state}


### PR DESCRIPTION
Undefined function error was causing a crash on reload - this handles
the case to prevent the huge error trace + worker crash.