### PR TITLE
Add file throttling

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+Unreleased
+==========
+
+  * feat: File throttling to prevent files being compiled multiple times in quick succession and tests being run multiple times due to one "change".
 
 0.5.0 / 2018-05-01
 ==================


### PR DESCRIPTION
Adds a simple throttle timer to group changes together and avoid tests running multiple times due to multiple file events being emitted by one editor save operation.

Fixes #9 
Code inspired by #21
Code based on #33  (to keep the formatting changes separate)