### PR TITLE
Clear screen before test run

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@ Unreleased
 ==========
 
   * feat: File throttling to prevent files being compiled multiple times in quick succession and tests being run multiple times due to one "change".
+  * feat: by default clear the screen before each test run (configurable with `clear_before_running_tests`)
 
 0.5.0 / 2018-05-01
 ==================

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ config :cortex,
   disabled: {:system, "CI_RUN", false}
 ```
 
+## Configuring
+
+```ex
+config :cortex,
+  clear_before_running_tests: true
+```
+
+Set `clear_before_running_tests` to clear the screen immediately before running tests, defaults to true.
+
 ## Phoenix
 
 If you are running a phoenix application,

--- a/config/config.exs
+++ b/config/config.exs
@@ -30,4 +30,5 @@ use Mix.Config
 #     import_config "#{Mix.env}.exs"
 config :cortex,
   enabled: {:system, "CORTEX_ENABLED", true},
-  disabled: {:system, "CORTEX_DISABLED", false}
+  disabled: {:system, "CORTEX_DISABLED", false},
+  clear_before_running_tests: true

--- a/lib/cortex/test_runner.ex
+++ b/lib/cortex/test_runner.ex
@@ -144,6 +144,10 @@ defmodule Cortex.TestRunner do
     # present
     if focus == nil, do: clear_focus()
 
+    if Application.get_env(:cortex, :clear_before_running_tests, true) do
+      IEx.Helpers.clear()
+    end
+
     files_to_load = [test_helper | files]
 
     compiler_errors =


### PR DESCRIPTION
Based on configuration, clear the screen before each test run, defaults to clearing.

~Based on #34~
Fixes #32 