### PR TITLE
Log when a file is recompiled

### DIFF
--- a/lib/cortex/reloader.ex
+++ b/lib/cortex/reloader.ex
@@ -109,11 +109,16 @@ defmodule Cortex.Reloader do
 
     Code.compiler_options(restore_opts)
 
+    if result == :ok do
+      Logger.debug("[cortex] reloaded #{path}")
+    end
+
     {:reply, result, state}
   end
 
   @impl GenServer
   def handle_call({:recompile}, _from, state) do
+    Logger.debug("[cortex] recompiling project")
     IEx.Helpers.recompile()
     {:reply, :ok, state}
   end

--- a/test/cortex/reloader_test.exs
+++ b/test/cortex/reloader_test.exs
@@ -19,13 +19,17 @@ defmodule Cortex.ReloaderTest do
     test "recompiles a file", %{state: state} do
       path = fixture_for("hello.ex")
 
-      {:reply, :ok, _} = Reloader.handle_call({:reload_file, path}, nil, state)
+      assert ExUnit.CaptureLog.capture_log(fn ->
+               {:reply, :ok, _} = Reloader.handle_call({:reload_file, path}, nil, state)
+             end) =~ "reloaded test/fixtures/hello.ex"
 
       assert Hello.hi() == "hello"
 
       path = fixture_for("hello_2.ex")
 
-      {:reply, :ok, _} = Reloader.handle_call({:reload_file, path}, nil, state)
+      assert ExUnit.CaptureLog.capture_log(fn ->
+               {:reply, :ok, _} = Reloader.handle_call({:reload_file, path}, nil, state)
+             end) =~ "reloaded test/fixtures/hello_2.ex"
 
       assert Hello.hi() == "goodbye"
     end


### PR DESCRIPTION
This is useful when you are running in dev mode. It is useful to know when the recompilation is finished.

Fixes #38