### PR TITLE
Fix Code.load_file deprecation

### DIFF
--- a/lib/cortex/reloader.ex
+++ b/lib/cortex/reloader.ex
@@ -71,7 +71,7 @@ defmodule Cortex.Reloader do
 
     {result, state} =
       try do
-        Code.load_file(path)
+        Code.compile_file(path)
 
         state =
           if MapSet.member?(state.paths_with_errors, path) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Cortex.Mixfile do
     [
       app: :cortex,
       version: "0.6.0",
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/urbint/cortex",


### PR DESCRIPTION
Code.load_file was deprecated in Elixir 1.10 (https://hexdocs.pm/elixir/compatibility-and-deprecations.html)

This replaces it with `Code.compile_file/1` (`Code.require_file/1` was not used because we want to be able to recompile the same file multiple times).

Since `Code.compile_file/1` was added in Elixir 1.7, support for 1.6 was removed. 1.7 was released in July 2018 so it is almost 2 years old at this point, so hopefully it is okay to drop support.

https://elixir-lang.org/blog/2018/07/25/elixir-v1-7-0-released/