### PR TITLE
docs: update `mix phx.server` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If you are running a phoenix application,
 make sure you are running the app in interactive mode:
 
 ```sh
-iex -S mix phoenix.server
+iex -S mix phx.server
 ```
 
 


### PR DESCRIPTION
The documented command should be this one instead: `iex -S mix phx.server`. The old `mix phoenix ...` command was deprecated.